### PR TITLE
Single-source the package version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Verify tag matches package version
+        run: python3 scripts/check_versions.py "${GITHUB_REF_NAME#v}"
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,13 @@
 #   make          - Build minified production version
 #   make dev      - Build non-minified development version
 #   make clean    - Remove build artifacts
-#   make release VERSION=x.y.z - Verify clean tree and tag for release
+#   make release VERSION=x.y.z - Verify clean tree + version consistency and tag for release
+#   make check-versions [VERSION=x.y.z] - Verify all version sources agree (and match VERSION if given)
 #   make docs-serve  - Serve docs locally at http://127.0.0.1:8000
 #   make docs-build  - Build docs with strict mode
 #
 
-.PHONY: all build dev clean release check-git check-version quality docs-serve docs-build
+.PHONY: all build dev clean release check-git check-version check-versions quality docs-serve docs-build
 
 # Default target - build production version
 all: build
@@ -63,9 +64,13 @@ check-version:
 	fi
 	@echo "Release version: $(VERSION)"
 
-# Release target - verify clean tree and tag
-# Run "make build" and commit before releasing
-release: check-version check-git
+# Check that all version sources agree (and match VERSION when provided)
+check-versions:
+	poetry run python scripts/check_versions.py $(VERSION)
+
+# Release target - verify clean tree + version consistency and tag
+# Run "make build" and commit before releasing (or use scripts/release.py to bump + build + commit)
+release: check-version check-git check-versions
 	@echo ""
 	@echo "Creating git tag v$(VERSION)..."
 	git tag -a "v$(VERSION)" -m "Release v$(VERSION)"

--- a/deckgl_dash/package-info.json
+++ b/deckgl_dash/package-info.json
@@ -1,6 +1,6 @@
 {
   "name": "deckgl_dash",
-  "version": "0.2.0",
+  "version": "0.10.0",
   "description": "Direct deck.gl wrapper for Plotly Dash",
   "main": "build/index.js",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deckgl_dash",
-  "version": "0.2.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deckgl_dash",
-      "version": "0.2.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@deck.gl-community/editable-layers": "^9.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deckgl_dash",
-  "version": "0.2.0",
+  "version": "0.10.0",
   "description": "Direct deck.gl wrapper for Plotly Dash",
   "main": "build/index.js",
   "scripts": {

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Verify the package version agrees across all files that declare it.
+
+Usage:
+    python scripts/check_versions.py            # fail if any source disagrees
+    python scripts/check_versions.py 0.10.0     # additionally fail if the agreed version != 0.10.0
+
+Stdlib-only so it can run in CI before any dependencies are installed.
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+
+
+def collect_versions() -> dict[str, str]:
+    """Return {source: version} for every file that declares the package version."""
+    versions = {}
+
+    match = re.search(r'^version = "([^"]+)"', (PROJECT_ROOT / "pyproject.toml").read_text(), re.MULTILINE)
+    versions["pyproject.toml"] = match.group(1) if match else "<not found>"
+
+    versions["package.json"] = json.loads((PROJECT_ROOT / "package.json").read_text()).get("version", "<not found>")
+
+    lock = json.loads((PROJECT_ROOT / "package-lock.json").read_text())
+    versions["package-lock.json"] = lock.get("version", "<not found>")
+    versions['package-lock.json packages[""]'] = lock.get("packages", {}).get("", {}).get("version", "<not found>")
+
+    versions["deckgl_dash/package-info.json"] = json.loads((PROJECT_ROOT / "deckgl_dash" / "package-info.json").read_text()).get("version", "<not found>")
+
+    # Generated R/Julia bindings are gitignored, so they only exist locally — skip when absent (e.g. fresh CI checkout)
+    if (PROJECT_ROOT / "DESCRIPTION").exists():
+        match = re.search(r'^Version: (.+)$', (PROJECT_ROOT / "DESCRIPTION").read_text(), re.MULTILINE)
+        versions["DESCRIPTION"] = match.group(1).strip() if match else "<not found>"
+
+    if (PROJECT_ROOT / "Project.toml").exists():
+        match = re.search(r'^version = "([^"]+)"', (PROJECT_ROOT / "Project.toml").read_text(), re.MULTILINE)
+        versions["Project.toml"] = match.group(1) if match else "<not found>"
+
+    return versions
+
+
+def check(expected: str | None = None) -> bool:
+    """Print all version sources and return True when they agree (and match `expected`, if given)."""
+    versions = collect_versions()
+    width = max(len(source) for source in versions)
+    for source, version in versions.items():
+        print(f"  {source:<{width}}  {version}")
+
+    distinct = set(versions.values())
+    if len(distinct) != 1:
+        print(f"\n❌ Version mismatch: found {sorted(distinct)}")
+        return False
+
+    agreed = distinct.pop()
+    if expected is not None and agreed != expected:
+        print(f"\n❌ Files say {agreed} but expected {expected}")
+        return False
+
+    print(f"\n✅ All sources agree on {agreed}" + (f" (matches expected {expected})" if expected else ""))
+    return True
+
+
+if __name__ == "__main__":
+    expected = sys.argv[1] if len(sys.argv) > 1 else None
+    sys.exit(0 if check(expected) else 1)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -5,18 +5,21 @@ Usage:
     python scripts/release.py 0.2.0
     python scripts/release.py 0.2.0 --dry-run  # Preview without making changes
 """
-import json
 import re
 import subprocess
 import sys
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
+from check_versions import check  # noqa: E402
 
+# package.json and package-lock.json are bumped via `npm version` (the source of truth); these follow.
 FILES_TO_UPDATE = [
     ("pyproject.toml", r'version = "[^"]+"', 'version = "{version}"'),
-    ("package.json", r'"version": "[^"]+"', '"version": "{version}"'),
     ("deckgl_dash/package-info.json", r'"version": "[^"]+"', '"version": "{version}"'),
+    ("DESCRIPTION", r'Version: [^\n]+', 'Version: {version}'),
+    ("Project.toml", r'version = "[^"]+"', 'version = "{version}"'),
 ]
 
 
@@ -32,6 +35,10 @@ def run(cmd: str, dry_run: bool = False) -> bool:
 def bump_version(new_version: str, dry_run: bool = False) -> bool:
     """Update version in all configuration files."""
     print(f"\n📝 Bumping version to {new_version}")
+
+    if not run(f"npm version {new_version} --no-git-tag-version --allow-same-version", dry_run):
+        print("❌ Error: npm version failed")
+        return False
 
     for filepath, pattern, replacement in FILES_TO_UPDATE:
         full_path = PROJECT_ROOT / filepath
@@ -75,7 +82,13 @@ def release(version: str, dry_run: bool = False) -> None:
         print("❌ Error: npm build failed")
         sys.exit(1)
 
-    # Step 3: Git add and commit
+    # Step 3: Verify every version source agrees before committing
+    print("\n🔍 Verifying version consistency")
+    if not dry_run and not check(expected=version):
+        print("❌ Error: version sources disagree — aborting before commit/tag")
+        sys.exit(1)
+
+    # Step 4: Git add and commit
     print("\n📝 Committing changes")
     if not run("git add -A", dry_run):
         sys.exit(1)
@@ -83,7 +96,7 @@ def release(version: str, dry_run: bool = False) -> None:
         print("❌ Error: git commit failed (maybe no changes?)")
         sys.exit(1)
 
-    # Step 4: Create tag
+    # Step 5: Create tag
     print("\n🏷️  Creating tag")
     if not run(f"git tag {tag}", dry_run):
         print("❌ Error: git tag failed (tag may already exist)")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,28 @@
+"""Tests that the package version is single-sourced and consistent across all files (issue #8 / T-01)."""
+import importlib.util
+import re
+from pathlib import Path
+
+import deckgl_dash
+
+PROJECT_ROOT = Path(__file__).parent.parent
+
+_spec = importlib.util.spec_from_file_location("check_versions", PROJECT_ROOT / "scripts" / "check_versions.py")
+assert _spec is not None and _spec.loader is not None
+check_versions = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(check_versions)
+
+
+def _pyproject_version() -> str:
+    match = re.search(r'^version = "([^"]+)"', (PROJECT_ROOT / "pyproject.toml").read_text(), re.MULTILINE)
+    assert match is not None, "no version found in pyproject.toml"
+    return match.group(1)
+
+
+def test_version_sources_agree():
+    versions = check_versions.collect_versions()
+    assert len(set(versions.values())) == 1, f"version sources disagree: {versions}"
+
+
+def test_runtime_version_matches_pyproject():
+    assert deckgl_dash.__version__ == _pyproject_version()


### PR DESCRIPTION
Closes #8 (T-01).

## Problem
Version disagreed across sources: `pyproject.toml` = 0.10.0 (what PyPI publishes, matches git tag) while `package.json`, `package-lock.json`, and `deckgl_dash/package-info.json` said 0.2.0 — so `deckgl_dash.__version__` reported 0.2.0 at runtime for a package installed as 0.10.0.

## Changes
- Sync all version files to **0.10.0**
- New `scripts/check_versions.py`: stdlib-only checker that fails when any version source disagrees (optionally against an expected version); tolerates the gitignored R/Julia artifacts being absent in CI
- `scripts/release.py`: bump the npm side via `npm version --no-git-tag-version` (covers both package-lock.json entries), bump `DESCRIPTION`/`Project.toml` when present, and verify consistency before commit/tag
- `Makefile`: new `check-versions` target wired into `make release` — tagging fails if any source disagrees with `VERSION`
- `publish.yml`: verify the pushed tag matches the committed version before building/publishing
- `tests/test_version.py`: drift regression tests

## Acceptance (from the issue)
- `python -c "import deckgl_dash; print(deckgl_dash.__version__)"` → `0.10.0`, matching `pyproject.toml` and the tag ✅
- `make release` fails if any source disagrees (verified with `VERSION=0.99.0`) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGRQWbBW1qH3UFfDEpxixp