### PR TITLE
Preserve leading underscores in to_camel_case

### DIFF
--- a/deckgl_dash/layers/base.py
+++ b/deckgl_dash/layers/base.py
@@ -59,9 +59,11 @@ def is_scale_accessor(value: Any) -> bool:
 
 
 def to_camel_case(snake_str: str) -> str:
-    """Convert snake_case to camelCase. Handles 'get_' prefix specially."""
-    components = snake_str.split('_')
-    return components[0] + ''.join(x.title() for x in components[1:])
+    """Convert snake_case to camelCase, preserving leading underscores (deck.gl experimental props like `_pathType`)."""
+    stripped = snake_str.lstrip('_')
+    prefix = snake_str[:len(snake_str) - len(stripped)]
+    components = stripped.split('_')
+    return prefix + components[0] + ''.join(x.title() for x in components[1:])
 
 
 class BaseLayer(ABC):

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -70,6 +70,12 @@ class TestToCamelCase:
     def test_already_camel(self):
         assert to_camel_case('fillColor') == 'fillColor'
 
+    def test_leading_underscore_preserved(self):
+        assert to_camel_case('_path_type') == '_pathType'
+
+    def test_leading_underscore_single_word(self):
+        assert to_camel_case('_subdivisions') == '_subdivisions'
+
 
 class TestGeoJsonLayer:
     """Tests for GeoJsonLayer."""
@@ -156,6 +162,10 @@ class TestPathLayer:
     def test_default_type_without_multi_color(self):
         layer = PathLayer(id = 'path', data = [], get_path = '@@=path')
         assert layer.to_dict()['@@type'] == 'PathLayer'
+
+    def test_path_type_prop_keeps_leading_underscore(self):
+        layer = PathLayer(id = 'path', data = [], _path_type = 'loop')
+        assert layer.to_dict()['_pathType'] == 'loop'
 
     def test_multi_color_changes_type(self):
         layer = PathLayer(id = 'track', data = [], get_path = '@@=path', get_color = '@@=segmentColors', multi_color = True)


### PR DESCRIPTION
Closes #11 (T-17).

`to_camel_case('_path_type')` split on `_`, dropped the empty leading component, and emitted `'PathType'` — deck.gl's prop is `_pathType`, so `PathLayer(_path_type='loop')` was silently ignored.

## Changes
- `to_camel_case` now strips leading underscores, converts the remainder, and re-prepends them — a general fix covering any experimental `_`-prefixed deck.gl prop
- Unit tests: `'_path_type'` → `'_pathType'`, `'_subdivisions'` unchanged, plus the issue's acceptance check `PathLayer(_path_type='loop').to_dict()['_pathType'] == 'loop'`

## Verification
- Full suite: 240 passed (3 new); existing conversion tests unchanged and green; `make quality` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGRQWbBW1qH3UFfDEpxixp