### PR TITLE
Stop silent viridis fallback in color_range_from_scale

### DIFF
--- a/deckgl_dash/colors.py
+++ b/deckgl_dash/colors.py
@@ -30,21 +30,46 @@ AVAILABLE_SCALES: Tuple[str, ...] = (
     'viridis', 'plasma', 'inferno', 'magma', 'cividis', 'turbo',
 )
 
-# Color definitions for Python-side scale generation (subset for color_range_from_scale)
+# Color definitions for Python-side scale generation. Must cover every name in AVAILABLE_SCALES
+# so color_range_from_scale agrees with the JS-side ColorScale accessor (chroma.js).
+# ColorBrewer scales use the canonical 9-class (sequential) / 11-class (diverging) hex values.
 _SCALE_COLORS = {
+    # Perceptually uniform
     'viridis': ['#440154', '#482878', '#3e4a89', '#31688e', '#26828e', '#1f9e89', '#35b779', '#6ece58', '#b5de2b', '#fde725'],
     'plasma': ['#0d0887', '#46039f', '#7201a8', '#9c179e', '#bd3786', '#d8576b', '#ed7953', '#fb9f3a', '#fdca26', '#f0f921'],
     'inferno': ['#000004', '#1b0c41', '#4a0c6b', '#781c6d', '#a52c60', '#cf4446', '#ed6925', '#fb9b06', '#f7d13d', '#fcffa4'],
     'magma': ['#000004', '#180f3d', '#440f76', '#721f81', '#9e2f7f', '#cd4071', '#f1605d', '#fd9668', '#feca8d', '#fcfdbf'],
     'cividis': ['#00204d', '#00336f', '#39486b', '#575c6d', '#6f7174', '#87877b', '#a09e81', '#bab587', '#d6cd8e', '#ffe945'],
     'turbo': ['#30123b', '#4662d7', '#35aaf9', '#1ae4b6', '#72fe5e', '#c8ef34', '#faba39', '#f66b19', '#ca2a04', '#7a0403'],
+    # Sequential (ColorBrewer, 9-class)
     'OrRd': ['#fff7ec', '#fee8c8', '#fdd49e', '#fdbb84', '#fc8d59', '#ef6548', '#d7301f', '#b30000', '#7f0000'],
-    'YlGnBu': ['#ffffd9', '#edf8b1', '#c7e9b4', '#7fcdbb', '#41b6c4', '#1d91c0', '#225ea8', '#253494', '#081d58'],
-    'RdYlBu': ['#a50026', '#d73027', '#f46d43', '#fdae61', '#fee090', '#ffffbf', '#e0f3f8', '#abd9e9', '#74add1', '#4575b4', '#313695'],
-    'Spectral': ['#9e0142', '#d53e4f', '#f46d43', '#fdae61', '#fee08b', '#ffffbf', '#e6f598', '#abdda4', '#66c2a5', '#3288bd', '#5e4fa2'],
-    'Blues': ['#f7fbff', '#deebf7', '#c6dbef', '#9ecae1', '#6baed6', '#4292c6', '#2171b5', '#08519c', '#08306b'],
+    'PuBu': ['#fff7fb', '#ece7f2', '#d0d1e6', '#a6bddb', '#74a9cf', '#3690c0', '#0570b0', '#045a8d', '#023858'],
+    'BuPu': ['#f7fcfd', '#e0ecf4', '#bfd3e6', '#9ebcda', '#8c96c6', '#8c6bb1', '#88419d', '#810f7c', '#4d004b'],
+    'Oranges': ['#fff5eb', '#fee6ce', '#fdd0a2', '#fdae6b', '#fd8d3c', '#f16913', '#d94801', '#a63603', '#7f2704'],
+    'BuGn': ['#f7fcfd', '#e5f5f9', '#ccece6', '#99d8c9', '#66c2a4', '#41ae76', '#238b45', '#006d2c', '#00441b'],
+    'YlOrBr': ['#ffffe5', '#fff7bc', '#fee391', '#fec44f', '#fe9929', '#ec7014', '#cc4c02', '#993404', '#662506'],
+    'YlGn': ['#ffffe5', '#f7fcb9', '#d9f0a3', '#addd8e', '#78c679', '#41ab5d', '#238443', '#006837', '#004529'],
     'Reds': ['#fff5f0', '#fee0d2', '#fcbba1', '#fc9272', '#fb6a4a', '#ef3b2c', '#cb181d', '#a50f15', '#67000d'],
+    'RdPu': ['#fff7f3', '#fde0dd', '#fcc5c0', '#fa9fb5', '#f768a1', '#dd3497', '#ae017e', '#7a0177', '#49006a'],
     'Greens': ['#f7fcf5', '#e5f5e0', '#c7e9c0', '#a1d99b', '#74c476', '#41ab5d', '#238b45', '#006d2c', '#00441b'],
+    'YlGnBu': ['#ffffd9', '#edf8b1', '#c7e9b4', '#7fcdbb', '#41b6c4', '#1d91c0', '#225ea8', '#253494', '#081d58'],
+    'Purples': ['#fcfbfd', '#efedf5', '#dadaeb', '#bcbddc', '#9e9ac8', '#807dba', '#6a51a3', '#54278f', '#3f007d'],
+    'GnBu': ['#f7fcf0', '#e0f3db', '#ccebc5', '#a8ddb5', '#7bccc4', '#4eb3d3', '#2b8cbe', '#0868ac', '#084081'],
+    'Greys': ['#ffffff', '#f0f0f0', '#d9d9d9', '#bdbdbd', '#969696', '#737373', '#525252', '#252525', '#000000'],
+    'YlOrRd': ['#ffffcc', '#ffeda0', '#fed976', '#feb24c', '#fd8d3c', '#fc4e2a', '#e31a1c', '#bd0026', '#800026'],
+    'PuRd': ['#f7f4f9', '#e7e1ef', '#d4b9da', '#c994c7', '#df65b0', '#e7298a', '#ce1256', '#980043', '#67001f'],
+    'Blues': ['#f7fbff', '#deebf7', '#c6dbef', '#9ecae1', '#6baed6', '#4292c6', '#2171b5', '#08519c', '#08306b'],
+    'PuBuGn': ['#fff7fb', '#ece2f0', '#d0d1e6', '#a6bddb', '#67a9cf', '#3690c0', '#02818a', '#016c59', '#014636'],
+    # Diverging (ColorBrewer, 11-class)
+    'Spectral': ['#9e0142', '#d53e4f', '#f46d43', '#fdae61', '#fee08b', '#ffffbf', '#e6f598', '#abdda4', '#66c2a5', '#3288bd', '#5e4fa2'],
+    'RdYlGn': ['#a50026', '#d73027', '#f46d43', '#fdae61', '#fee08b', '#ffffbf', '#d9ef8b', '#a6d96a', '#66bd63', '#1a9850', '#006837'],
+    'RdBu': ['#67001f', '#b2182b', '#d6604d', '#f4a582', '#fddbc7', '#f7f7f7', '#d1e5f0', '#92c5de', '#4393c3', '#2166ac', '#053061'],
+    'PiYG': ['#8e0152', '#c51b7d', '#de77ae', '#f1b6da', '#fde0ef', '#f7f7f7', '#e6f5d0', '#b8e186', '#7fbc41', '#4d9221', '#276419'],
+    'PRGn': ['#40004b', '#762a83', '#9970ab', '#c2a5cf', '#e7d4e8', '#f7f7f7', '#d9f0d3', '#a6dba0', '#5aae61', '#1b7837', '#00441b'],
+    'RdYlBu': ['#a50026', '#d73027', '#f46d43', '#fdae61', '#fee090', '#ffffbf', '#e0f3f8', '#abd9e9', '#74add1', '#4575b4', '#313695'],
+    'BrBG': ['#543005', '#8c510a', '#bf812d', '#dfc27d', '#f6e8c3', '#f5f5f5', '#c7eae5', '#80cdc1', '#35978f', '#01665e', '#003c30'],
+    'RdGy': ['#67001f', '#b2182b', '#d6604d', '#f4a582', '#fddbc7', '#ffffff', '#e0e0e0', '#bababa', '#878787', '#4d4d4d', '#1a1a1a'],
+    'PuOr': ['#7f3b08', '#b35806', '#e08214', '#fdb863', '#fee0b6', '#f7f7f7', '#d8daeb', '#b2abd2', '#8073ac', '#542788', '#2d004b'],
 }
 
 
@@ -201,11 +226,7 @@ def color_range_from_scale(scale_name: str, steps: int = 6, reverse: bool = Fals
         [[68, 1, 84], [59, 82, 139], [33, 144, 140], [93, 201, 99], [253, 231, 37]]
     """
     if scale_name not in _SCALE_COLORS:
-        # Fall back to a default if not in our Python-side definitions
-        if scale_name not in AVAILABLE_SCALES:
-            raise ValueError(f"Unknown scale '{scale_name}'. Available scales: {', '.join(AVAILABLE_SCALES)}")
-        # Use viridis as fallback for scales we don't have Python definitions for
-        scale_name = 'viridis'
+        raise ValueError(f"Unknown scale '{scale_name}'. Available scales: {', '.join(AVAILABLE_SCALES)}")
 
     colors = _SCALE_COLORS[scale_name]
     n = len(colors)

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -125,6 +125,16 @@ class TestColorRangeFromScale:
         with pytest.raises(ValueError, match="Unknown scale"):
             color_range_from_scale('not_a_real_scale', 6)
 
+    def test_every_available_scale_has_own_colors(self):
+        """Every advertised scale returns its own colors — no silent viridis substitution (issue #12)."""
+        from deckgl_dash.colors import _SCALE_COLORS, _hex_to_rgb
+        assert set(_SCALE_COLORS) == set(AVAILABLE_SCALES)
+        for name in AVAILABLE_SCALES:
+            colors = color_range_from_scale(name, 6)
+            assert len(colors) == 6
+            assert colors[0] == list(_hex_to_rgb(_SCALE_COLORS[name][0])), f"{name}: first color wrong"
+            assert colors[-1] == list(_hex_to_rgb(_SCALE_COLORS[name][-1])), f"{name}: last color wrong"
+
 
 class TestAvailableScales:
     """Tests for AVAILABLE_SCALES constant."""


### PR DESCRIPTION
Closes #12 (T-18).

## Problem
`AVAILABLE_SCALES` advertises 33 scale names but `_SCALE_COLORS` defined only 13; for the other 20 (e.g. `PuBu`, `RdBu`, `RdYlGn`), `color_range_from_scale` silently substituted viridis — disagreeing with the JS-side `ColorScale` accessor, which supports all 33 via chroma.js.

## Changes
- Added the 20 missing ColorBrewer definitions (canonical 9-class sequential / 11-class diverging hex values)
- Removed the silent fallback — unknown scale names now raise `ValueError` (as `ColorScale` already did)
- New test iterates all 33 scales: each returns its own endpoint colors, and `_SCALE_COLORS` covers `AVAILABLE_SCALES` exactly

## Verification
- All 20 new palettes verified **byte-identical to `chroma.brewer`** in the bundled chroma-js, so the Python and JS color paths now agree
- Full suite: 238 passed; `make quality` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGRQWbBW1qH3UFfDEpxixp