### PR TITLE
Remove unimplemented COG/GeoTIFF claim

### DIFF
--- a/deckgl_dash/__init__.py
+++ b/deckgl_dash/__init__.py
@@ -1,7 +1,7 @@
 """deckgl-dash: Direct deck.gl wrapper for Plotly Dash.
 
-High-performance WebGL-powered visualization with support for large vector datasets,
-Cloud Optimized GeoTIFFs (COGs), and tile-based base maps.
+High-performance WebGL-powered visualization with support for large vector datasets
+and tile-based base maps.
 
 Example:
     >>> from dash import Dash


### PR DESCRIPTION
Closes #14 (T-24).

The package docstring (`deckgl_dash/__init__.py`) advertised "Cloud Optimized GeoTIFFs (COGs)", but no COG code, example, doc, or dependency exists anywhere in the repo.

## Changes
- Removed the COG claim from the package docstring
- `CLAUDE.md` (gitignored, local-only) also claimed a `@developmentseed/deck.gl-geotiff` dependency — fixed in the local copy; nothing to commit since it isn't tracked

## Verification
- Repo-wide grep for `geotiff` / `Cloud Optimized` / `COG` across README, Python sources, docs/, examples/, and src/lib/ comes back clean
- Full suite passes; `make quality` clean

If COG support is still on the roadmap, a separate feature issue can track implementing it (e.g. via `@developmentseed/deck.gl-geotiff` or a TileLayer + titiler pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGRQWbBW1qH3UFfDEpxixp