### PR TITLE
Verify Dash 3/4 support and raise the dash constraint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
+        dash-version: ['3.4.0', '4.3.0']
 
     steps:
       - uses: actions/checkout@v4
@@ -38,6 +39,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install poetry
           poetry install
+          poetry run pip install "dash[testing]==${{ matrix.dash-version }}"
 
       - name: Run Pyright type checker
         run: poetry run npx pyright deckgl_dash/ examples/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Direct deck.gl wrapper for Plotly Dash - high-performance WebGL-powered visualiz
 pip install deckgl-dash
 ```
 
+Requires Python >= 3.10 and Dash >= 3.0 (Dash 3.x and 4.x are both supported and tested).
+
 ## Quick Start
 
 ```python

--- a/poetry.lock
+++ b/poetry.lock
@@ -2070,4 +2070,4 @@ test = ["h3"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "9f882570ff447fd13b83f88bc474c31f90d6f16ab9e3fa5eb81b9bb29ade145f"
+content-hash = "bd4ef789ca909cf6c28a0da7c9697b7e22f916d25b55f162bd3b0f813c4ebe17"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.10"
-dash = ">=2.0.0"
+dash = ">=3.0.0,<5"
 h3 = {version = "^4.0.0", optional = true}
 pyproj = {version = ">=3.0.0", optional = true}
 mgrs = {version = ">=1.4.0", optional = true}


### PR DESCRIPTION
Closes #18 (T-32).

**Stacked on #53.** Merge order: #43 → #51 → #52 → #53 → this.

## Verification performed
- `DeckGL.react.js`: no function-component `defaultProps`, no `loading_state` usage (grep clean)
- **dash 4.3.0**: full pytest suite 239 passed + all 4 browser smoke tests (custom path layers, drawing + time filter, MapLibre interleaved, style diff-swap) pass
- **dash 3.4.0** (locked version): same, green

## Changes
- `pyproject.toml`: `dash >=3.0.0,<5` — the honest, tested constraint (was `>=2.0.0`, but dash 2.5-era releases crash on modern Flask, so the old floor was already fiction)
- README: documents Python ≥ 3.10 and Dash ≥ 3.0 (3.x/4.x supported)
- CI: test matrix now crosses `python-version` × `dash-version` (3.4.0, 4.3.0) — the dash override installs via pip after `poetry install`, since Poetry's lock pins one version

Note: per the issue, `dash[testing]` caps selenium at `<=4.2.0` in both v3 and v4, so the selenium pin from #51 stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGRQWbBW1qH3UFfDEpxixp