### PR TITLE
Adopt two-job OIDC publish pipeline

### DIFF
--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -8,26 +8,21 @@ on:
     tags:
       - 'v*-*'
 
-jobs:
-  publish-test:
-    runs-on: ubuntu-latest
-    environment: test-release
-    permissions:
-      id-token: write
+permissions:
+  contents: read
 
+jobs:
+  build:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
+          cache-dependency-path: package-lock.json
 
       - name: Install npm dependencies
         run: npm ci
@@ -35,21 +30,43 @@ jobs:
       - name: Build JavaScript bundle
         run: npm run build:js
 
-      - name: Install Python dependencies
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Build Python package
         run: |
           python -m pip install --upgrade pip
           pip install poetry
-
-      - name: Build Python package
-        run: poetry build
+          poetry build
 
       - name: Verify package with twine
         run: |
           pip install twine
           twine check dist/*
 
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-testpypi:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: test-release
+    permissions:
+      id-token: write  # Trusted publishing via OIDC
+
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,29 +6,26 @@ on:
       # Only clean version tags (v0.1.0), not pre-release (v0.1.0-test, v0.1.0-rc1)
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
-jobs:
-  publish:
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      id-token: write  # Required for trusted publishing
+permissions:
+  contents: read
 
+jobs:
+  # Build runs npm ci (hundreds of packages' postinstall scripts) — it holds no
+  # publish credentials. Only the artifact it produces crosses into the publish job.
+  build:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: Verify tag matches package version
         run: python3 scripts/check_versions.py "${GITHUB_REF_NAME#v}"
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
+          cache-dependency-path: package-lock.json
 
       - name: Install npm dependencies
         run: npm ci
@@ -36,20 +33,43 @@ jobs:
       - name: Build JavaScript bundle
         run: npm run build:js
 
-      - name: Install Python dependencies
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Build Python package
         run: |
           python -m pip install --upgrade pip
           pip install poetry
-
-      - name: Build Python package
-        run: poetry build
+          poetry build
 
       - name: Verify package with twine
         run: |
           pip install twine
           twine check dist/*
 
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  # Least-privilege publish: downloads the artifact and publishes via OIDC trusted
+  # publishing only — no npm, no build code, no token secret.
+  publish-pypi:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write  # Trusted publishing via OIDC
+
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,9 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
+          cache-dependency-path: package-lock.json
 
       - name: Install npm dependencies
         run: npm ci
@@ -47,8 +48,35 @@ jobs:
       - name: Run Python tests
         run: poetry run pytest tests/ -v
 
+  # Build the wheel once per PR (was previously repeated inside the test matrix)
+  build-package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build JavaScript bundle
+        run: npm run build:js
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Build Python package
-        run: poetry build
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry build
 
       - name: Verify package with twine
         run: |


### PR DESCRIPTION
Closes #22 (T-15).

**Stacked on #55.** Merge order: #43 → #51 → #52 → #53 → #54 → #55 → this. (Stacked here because the Node 20 bump pairs with #55's webpack-cli 7, and the tag-verification step comes from #43.)

## Changes
- **publish.yml / publish-test.yml**: two-job shape from `deckgl-marimo` — `build` (npm ci, bundle, `poetry build`, `twine check`, upload `dist/`) and `publish-pypi`/`publish-testpypi` (`environment` + `id-token: write`, downloads artifact, runs `pypa/gh-action-pypi-publish` with **no `password:`**). The job holding publish rights executes no npm or build code
- **Node 18 (EOL) → 20** in all workflows + `cache-dependency-path`
- **test.yml**: `poetry build` + `twine check` moved out of the 6-way matrix into a single `build-package` job (wheel built once per PR)
- Tag-push trigger retained so `scripts/release.py`'s documented flow keeps working; switching to `release: published` as a human gate is still open if you want it

## ⚠️ Action needed before a real release
Trusted publishing must be configured once on PyPI (and TestPyPI): add a **Trusted Publisher** for `kihaji/deckgl-dash`, workflow `publish.yml` (/ `publish-test.yml`), environment `release` (/ `test-release`). Until then the publish job would fail — the old `PYPI_API_TOKEN` secret is no longer referenced. The TestPyPI workflow's `workflow_dispatch` trigger makes for an easy OIDC dry-run once configured.

## Verification
- All four workflow files parse as valid YAML; `grep password` across workflows is empty; every `node-version` is 20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGRQWbBW1qH3UFfDEpxixp