### PR TITLE
Stop shipping the 10 MB source map in the wheel

### DIFF
--- a/deckgl_dash/__init__.py
+++ b/deckgl_dash/__init__.py
@@ -114,14 +114,20 @@ _js_dist.extend(
         {
             'relative_package_path': 'deckgl_dash.min.js',
             'namespace': package_name
-        },
+        }
+    ]
+)
+
+# The source map is excluded from the wheel (pyproject `exclude`) to save ~10 MB;
+# only declare it when present (dev checkouts) so Dash never references a missing file.
+if _os.path.exists(_os.path.join(_basepath, 'deckgl_dash.min.js.map')):
+    _js_dist.append(
         {
             'relative_package_path': 'deckgl_dash.min.js.map',
             'namespace': package_name,
             'dynamic': True
         }
-    ]
-)
+    )
 
 _css_dist = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ authors = ["Scott"]
 readme = "README.md"
 license = "MIT"
 packages = [{include = "deckgl_dash"}]
+exclude = ["deckgl_dash/*.map"]  # 10 MB source map stays in git for dev, out of the wheel
 classifiers = [
     "Framework :: Dash",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Closes #23 (T-16).

## Changes
- `pyproject.toml`: `exclude = ["deckgl_dash/*.map"]` — the map stays git-tracked for development but leaves the wheel
- `deckgl_dash/__init__.py`: the `_js_dist` source-map entry is now conditional on the file existing, so wheel installs never declare a missing resource while dev checkouts keep devtools sourcemaps

## Verification
- Wheel: **3,277,736 → 829,801 bytes** (the map was 10.5 MB uncompressed / 2.4 MB compressed inside the zip)
- Clean-venv install from the wheel: Dash serves the full 2.9 MB bundle at `/_dash-component-suites/...`, `_js_dist` has no map entry
- Dev checkout: map entry present as before
- 237 tests pass; `make quality` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGRQWbBW1qH3UFfDEpxixp