### PR TITLE
Document the @@= expression security posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ if __name__ == '__main__':
 - **Remote Data Loading**: Load data directly from external servers in the browser with `load_options`, including client certificate (mTLS) support
 - **Data-driven Styling**: Built-in color scales powered by chroma.js
 
+### Accessors and security
+
+Layer props accept `@@=` accessor strings (e.g. `get_fill_color='@@=properties.color'`) that are evaluated per-datum in the browser.
+
+> **Security note:** `@@=` expressions are compiled to JavaScript with `new Function` and run in the browser, in the same trust domain as your app code. Only pass accessor strings that you, the app author, wrote. **Never build an `@@=` accessor from end-user input** (form fields, URL params, uploaded content) — that would be equivalent to letting users inject script into your page.
+
 ## MapLibre GL JS Integration
 
 Use MapLibre GL JS as the basemap renderer with deck.gl layers as overlays. This gives you access to vector tile basemaps (CARTO, OpenFreeMap, MapTiler) with full styling control.

--- a/docs/api/core-layers.md
+++ b/docs/api/core-layers.md
@@ -44,6 +44,9 @@ get_fill_color='@@=properties.color'    # Access nested property
 get_radius='@@=radius'                   # Access top-level property
 ```
 
+> **Security note:** `@@=` expressions are compiled to JavaScript with `new Function` and run in the browser, in the same trust domain as your app code. Only pass accessor strings that you, the app author, wrote. **Never build an `@@=` accessor from end-user input** (form fields, URL params, uploaded content) — that would be equivalent to letting users inject script into your page.
+
+
 ---
 
 ## GeoJsonLayer


### PR DESCRIPTION
Closes #33 (T-19).

## Changes
- README: new **"Accessors and security"** subsection under Features explaining that `@@=` strings compile via `new Function` in the browser, run in the app's trust domain, and must never be built from end-user input
- `docs/api/core-layers.md`: same note directly under the Accessor Syntax section

The optional hardening the issue mentions (deckgl-marimo's eval-free column-name fast path in its accessor resolver) is left for a future enhancement — `parseAccessor` already routes plain property paths through a non-eval path; only expressions with operators hit `new Function`.

## Verification
- `make docs-build` (mkdocs `--strict`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGRQWbBW1qH3UFfDEpxixp