### PR TITLE
Add "Choosing a basemap" guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,20 @@ Direct deck.gl wrapper for Plotly Dash - high-performance WebGL-powered visualiz
 pip install deckgl-dash
 ```
 
+## Choosing a Basemap
+
+There are two basemap paths — pick based on what you need:
+
+| | **MapLibre GL JS** (`maplibre_config`) | **Bare `TileLayer`** |
+|---|---|---|
+| Best for | Real basemaps: vector styles, WMS, runtime style switching, labels, attribution | Zero-config demos, deck-only rendering, single raster tile source |
+| Styles | Full MapLibre style JSON (CARTO, custom, WMS sources) | One raster tile URL template |
+| Attribution | Built-in control | Manual |
+| Interleaving | deck.gl layers can render under map labels (`interleaved`) | n/a — everything is a deck.gl layer |
+| Example | [`examples/maplibre_demo.py`](examples/maplibre_demo.py), [`examples/maplibre_wms_demo.py`](examples/maplibre_wms_demo.py) | [`examples/basic_usage.py`](examples/basic_usage.py) |
+
+The Quick Start below uses the **bare `TileLayer`** path for zero configuration; for anything beyond a quick demo, start from the [MapLibre GL JS Integration](#maplibre-gl-js-integration) section instead.
+
 ## Quick Start
 
 ```python

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -4,6 +4,10 @@ deckgl-dash supports two usage modes: **Python helper classes** (recommended) an
 
 ## Your First Map
 
+!!! tip "Choosing a basemap"
+    This page demonstrates the **bare `TileLayer`** basemap path — zero configuration, one raster tile URL. For real basemaps (vector styles, WMS sources, runtime style switching, built-in attribution), use **MapLibre** via `maplibre_config` — see the [MapLibre Integration guide](../guides/maplibre-integration.md).
+
+
 === "Python Helpers"
 
     ```python


### PR DESCRIPTION
Closes #34 (T-25).

**Stacked on #57** because the README's example link points to `examples/basic_usage.py`, which #57 creates (the old root `usage.py` relocation).

## Changes
- README: **"Choosing a Basemap"** decision table right above Quick Start — MapLibre (`maplibre_config`) for real basemaps/vector styles/WMS/attribution/interleaving vs bare `TileLayer` for zero-config or deck-only, each linked to its example; Quick Start now states which path it demonstrates
- Docs quick-start: `tip` admonition stating it uses the TileLayer path, linking the MapLibre Integration guide

## Verification
- `make docs-build` (mkdocs `--strict`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGRQWbBW1qH3UFfDEpxixp