### PR TITLE
Stop generating R/Julia bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,15 +286,3 @@ DeckGL_Wrapper.md
 
 # Backup files
 *.bak
-
-# Auto-generated R and Julia bindings (Dash build tooling)
-R/
-man/
-inst/
-deps/
-.Rbuildignore
-DESCRIPTION
-NAMESPACE
-Project.toml
-src/DeckglDash.jl
-src/jl/

--- a/deckgl_dash/package-info.json
+++ b/deckgl_dash/package-info.json
@@ -8,7 +8,7 @@
     "validate-init": "poetry run python _validate_init.py",
     "prepublishOnly": "npm run validate-init",
     "build:js": "webpack --mode production",
-    "build:backends": "poetry run dash-generate-components ./src/lib/components deckgl_dash -p package-info.json --r-prefix '' --jl-prefix '' --ignore \\.test\\.",
+    "build:backends": "poetry run dash-generate-components ./src/lib/components deckgl_dash -p package-info.json --ignore \"\\.test\\.|hooks\"",
     "build:py": "npm run build:backends",
     "build": "npm run build:js && npm run build:backends",
     "build:all": "npm run build:js && npm run build:backends",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "validate-init": "poetry run python _validate_init.py",
     "prepublishOnly": "npm run validate-init",
     "build:js": "webpack --mode production",
-    "build:backends": "poetry run dash-generate-components ./src/lib/components deckgl_dash -p package-info.json --r-prefix '' --jl-prefix '' --ignore \\.test\\.",
+    "build:backends": "poetry run dash-generate-components ./src/lib/components deckgl_dash -p package-info.json --ignore \"\\.test\\.|hooks\"",
     "build:py": "npm run build:backends",
     "build": "npm run build:js && npm run build:backends",
     "build:all": "npm run build:js && npm run build:backends",

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -31,15 +31,6 @@ def collect_versions() -> dict[str, str]:
     pkg_info = json.loads((PROJECT_ROOT / "deckgl_dash" / "package-info.json").read_text())
     versions["deckgl_dash/package-info.json"] = pkg_info.get("version", "<not found>")
 
-    # Generated R/Julia bindings are gitignored, so they only exist locally — skip when absent (e.g. fresh CI checkout)
-    if (PROJECT_ROOT / "DESCRIPTION").exists():
-        match = re.search(r'^Version: (.+)$', (PROJECT_ROOT / "DESCRIPTION").read_text(), re.MULTILINE)
-        versions["DESCRIPTION"] = match.group(1).strip() if match else "<not found>"
-
-    if (PROJECT_ROOT / "Project.toml").exists():
-        match = re.search(r'^version = "([^"]+)"', (PROJECT_ROOT / "Project.toml").read_text(), re.MULTILINE)
-        versions["Project.toml"] = match.group(1) if match else "<not found>"
-
     return versions
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -18,8 +18,6 @@ from check_versions import check  # noqa: E402
 FILES_TO_UPDATE = [
     ("pyproject.toml", r'version = "[^"]+"', 'version = "{version}"'),
     ("deckgl_dash/package-info.json", r'"version": "[^"]+"', '"version": "{version}"'),
-    ("DESCRIPTION", r'Version: [^\n]+', 'Version: {version}'),
-    ("Project.toml", r'version = "[^"]+"', 'version = "{version}"'),
 ]
 
 


### PR DESCRIPTION
Closes #36 (T-27).

**Stacked on #69** (end of the main chain — shares the `build:backends` script line with #67 and the version scripts with #43).

## Changes
- `build:backends` drops `--r-prefix '' --jl-prefix ''` → `dash-generate-components` emits Python only
- Also adds `hooks` to the generator's `--ignore` regex — react-docgen printed a non-fatal "No suitable component definition" error for each of #62's hook modules
- Deleted the on-disk generated trees (R: `R/`, `man/`, `inst/`, `DESCRIPTION`, `NAMESPACE`, `.Rbuildignore`; Julia: `Project.toml`, `deps/`, `src/DeckglDash.jl`, `src/jl/`) and trimmed the `.gitignore` block
- `scripts/release.py` and `scripts/check_versions.py` drop their DESCRIPTION/Project.toml follower entries

## Verification
- `npm run build:py` generates `DeckGL.py` only, no R/Julia output, no react-docgen errors (the pre-existing "Description for DeckGL is missing" notice remains — that's the component JSDoc placement, unrelated)
- `check_versions.py 0.10.0` passes; `release.py --dry-run` updates only Python-side files; 239 tests; `make quality` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGRQWbBW1qH3UFfDEpxixp