### PR TITLE
Validate layer props with "did you mean?" errors

### DIFF
--- a/deckgl_dash/layers/base.py
+++ b/deckgl_dash/layers/base.py
@@ -97,6 +97,8 @@ _UNIVERSAL_PROPS = frozenset({
     'extensions', 'update_triggers', 'load_options', 'transitions',
     # GPU time filtering works on any layer via DataFilterExtension
     'get_filter_value', 'filter_range', 'filter_soft_range', 'filter_enabled',
+    # Zoom-gated visibility (#38) applies to any layer
+    'visible_min_zoom', 'visible_max_zoom',
 })
 
 

--- a/deckgl_dash/layers/base.py
+++ b/deckgl_dash/layers/base.py
@@ -1,8 +1,9 @@
 """Base layer class for dash-deckgl Python layer helpers."""
 from __future__ import annotations
-import re
-from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+import difflib
+import inspect
+from abc import ABC
+from typing import Any, ClassVar, Dict, List, Optional, Sequence, Tuple, Union
 
 # Type aliases for color values
 ColorRGB = Tuple[int, int, int]
@@ -66,6 +67,59 @@ def to_camel_case(snake_str: str) -> str:
     return prefix + components[0] + ''.join(x.title() for x in components[1:])
 
 
+
+def _collect_kwargs(cls: type) -> frozenset:
+    """Union all keyword parameter names declared by __init__ across cls's MRO.
+
+    Variadic *args/**kwargs and self are skipped. Runs at class-creation time via
+    __init_subclass__, so it captures the full typed signature of each layer.
+    """
+    valid: set = set()
+    for klass in cls.__mro__:
+        if klass is object:
+            continue
+        init = klass.__dict__.get('__init__')
+        if init is None:
+            continue
+        try:
+            sig = inspect.signature(init)
+        except (ValueError, TypeError):
+            continue
+        for name, param in sig.parameters.items():
+            if name == 'self' or param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
+                continue
+            valid.add(name)
+    return frozenset(valid)
+
+
+# deck.gl base-Layer props valid on every layer; accepted via **kwargs without per-class declarations
+_UNIVERSAL_PROPS = frozenset({
+    'extensions', 'update_triggers', 'load_options', 'transitions',
+    # GPU time filtering works on any layer via DataFilterExtension
+    'get_filter_value', 'filter_range', 'filter_soft_range', 'filter_enabled',
+})
+
+
+def _raise_for_unknown_props(cls_name: str, props: Dict[str, Any], valid: frozenset) -> None:
+    """Raise TypeError listing unknown keys with difflib "did you mean" suggestions."""
+    unknown = [k for k in props if k not in valid and k not in _UNIVERSAL_PROPS]
+    if not unknown:
+        return
+    valid_sorted = sorted(valid)
+    lines = []
+    for key in unknown:
+        matches = difflib.get_close_matches(key, valid_sorted, n = 3, cutoff = 0.6)
+        if matches:
+            hint = ', '.join(repr(m) for m in matches)
+            lines.append(f"  '{key}' — did you mean: {hint}?")
+        else:
+            lines.append(f"  '{key}'")
+    raise TypeError(
+        f"Unknown property/properties for {cls_name}:\n" + '\n'.join(lines) +
+        '\n(Pass _unsafe_props=True to bypass this check, e.g. for deck.gl props this wrapper does not declare yet.)'
+    )
+
+
 class BaseLayer(ABC):
     """Abstract base class for all deck.gl layer helpers.
 
@@ -81,14 +135,25 @@ class BaseLayer(ABC):
     _color_props: Tuple[str, ...] = ()
     # Properties that can accept accessor strings (@@=...)
     _accessor_props: Tuple[str, ...] = ()
+    # Union of declared kwargs across the class and its ancestors; None on BaseLayer
+    # itself (no validation for direct/dict-style use). Set by __init_subclass__.
+    _VALID_PROPS: ClassVar[Optional[frozenset]] = None
 
-    def __init__(self, id: str, **kwargs):
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        cls._VALID_PROPS = _collect_kwargs(cls)
+
+    def __init__(self, id: str, _unsafe_props: bool = False, **kwargs):
         """Initialize layer with id and properties.
 
         Args:
             id: Unique identifier for the layer
+            _unsafe_props: Skip unknown-prop validation (escape hatch for deck.gl
+                props this wrapper does not declare yet)
             **kwargs: Layer-specific properties in snake_case
         """
+        if not _unsafe_props and self._VALID_PROPS is not None:
+            _raise_for_unknown_props(type(self).__name__, kwargs, self._VALID_PROPS)
         self._id = id
         self._props: Dict[str, Any] = {}
         for key, value in kwargs.items():

--- a/deckgl_dash/layers/base.py
+++ b/deckgl_dash/layers/base.py
@@ -99,6 +99,8 @@ _UNIVERSAL_PROPS = frozenset({
     'get_filter_value', 'filter_range', 'filter_soft_range', 'filter_enabled',
     # Zoom-gated visibility (#38) applies to any layer
     'visible_min_zoom', 'visible_max_zoom',
+    # Binary transport opt-in (#39) applies to any layer
+    'use_binary',
 })
 
 

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -119,10 +119,12 @@ class TestGeoJsonLayer:
         assert d['pickable'] is True
         assert d['opacity'] == 0.8
 
-    def test_extra_kwargs(self):
-        layer = GeoJsonLayer(id = 'test', data = [], custom_prop = 'value')
-        d = layer.to_dict()
-        assert d['customProp'] == 'value'
+    def test_extra_kwargs_require_unsafe_props(self):
+        # Unknown props raise by default (see TestPropValidation); _unsafe_props restores passthrough
+        with pytest.raises(TypeError, match = 'custom_prop'):
+            GeoJsonLayer(id = 'test', data = [], custom_prop = 'value')
+        layer = GeoJsonLayer(id = 'test', data = [], custom_prop = 'value', _unsafe_props = True)
+        assert layer.to_dict()['customProp'] == 'value'
 
     def test_repr(self):
         layer = GeoJsonLayer(id = 'test', data = 'url', pickable = True)
@@ -452,3 +454,31 @@ class TestLoadOptions:
         assert d['loadOptions']['fetch']['credentials'] == 'include'
         assert d['loadOptions']['fetch']['headers']['X-Custom'] == 'value'
         assert d['loadOptions']['fetch']['mode'] == 'cors'
+
+
+class TestPropValidation:
+    """Unknown/misspelled props raise with 'did you mean' suggestions (issue #37)."""
+
+    def test_misspelled_prop_suggests_correction(self):
+        with pytest.raises(TypeError) as exc:
+            ScatterplotLayer('s', [], get_fil_color = '#f00')
+        assert 'get_fill_color' in str(exc.value)
+        assert 'get_fil_color' in str(exc.value)
+
+    def test_unsafe_props_restores_passthrough(self):
+        layer = ScatterplotLayer('s', [], get_fil_color = '#f00', _unsafe_props = True)
+        assert layer.to_dict()['getFilColor'] == '#f00'
+
+    def test_universal_deckgl_props_allowed(self):
+        d = ArcLayer(id = 'a', data = [], extensions = ['DataFilterExtension'], get_filter_value = '@@=t',
+                     update_triggers = {'getSourceColor': [1]}).to_dict()
+        assert d['extensions'] == ['DataFilterExtension']
+        assert d['getFilterValue'] == '@@=t'
+
+    def test_no_suggestion_for_garbage(self):
+        with pytest.raises(TypeError, match = 'zzz_nonsense'):
+            ScatterplotLayer('s', [], zzz_nonsense = 1)
+
+    def test_valid_props_unaffected(self):
+        d = ScatterplotLayer('s', [], get_radius = 4, radius_min_pixels = 1).to_dict()
+        assert d['getRadius'] == 4


### PR DESCRIPTION
Closes #37 (T-34).

**Stacked on #63** per the issue's "do after T-07" (both rework `BaseLayer.__init__`). Chain: #46 → #63 → this.

## Changes (deckgl-marimo port, `_base.py:19-67` shape)
- `__init_subclass__` + `_collect_kwargs` union every `__init__` signature across the MRO into a frozen `_VALID_PROPS` per class (computed once at class creation)
- Unknown `**kwargs` raise `TypeError` with `difflib.get_close_matches` suggestions:
  ```
  Unknown property/properties for ScatterplotLayer:
    'get_fil_color' — did you mean: 'get_fill_color', 'get_line_color'?
  (Pass _unsafe_props=True to bypass this check, ...)
  ```
- **`_unsafe_props=True`** escape hatch restores full passthrough
- **`_UNIVERSAL_PROPS`**: `extensions`, `update_triggers`, `load_options`, `transitions` + the four time-filter props stay valid on every layer without per-class declarations — the existing time-filter tests attach filters to layers that don't declare those params, which surfaced this immediately
- `BaseLayer` used directly keeps catch-all behavior (`_VALID_PROPS is None`)
- maplibre bases need nothing: they have no `**kwargs` catch-all, so unknown props already raise

## Behavior change note
`test_extra_kwargs` previously asserted arbitrary kwargs pass through silently — that's exactly the failure mode this issue eliminates; updated to assert the raise + the `_unsafe_props` path.

## Verification
- Acceptance case verified: `ScatterplotLayer('s', [], get_fil_color='#f00')` raises naming `get_fill_color`; `_unsafe_props=True` passes it through
- 245 tests pass (5 new); `make quality` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGRQWbBW1qH3UFfDEpxixp