### PR TITLE
Bump pytest to 9.x

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1635,20 +1635,20 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.1.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"},
+    {file = "pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 
@@ -2140,4 +2140,4 @@ test = ["h3"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "a5e3773328e28706b8d6183f49c9fde0c25d581adcaaefb927ae3487b8993f32"
+content-hash = "e6a7e8be3b8e9c4d444b7820c365074c6d51f41b6457ae319c4f21e8b9f562dc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ test = ["h3"]
 coordinates = ["pyproj", "mgrs"]
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^8.0.0"
+pytest = "^9.0.0"
 dash = {extras = ["testing"], version = "^3.4"}
 pyyaml = "^6.0.3"
 selenium = ">=4.1,<4.3"  # floor at 4.x (3.141 breaks with urllib3 2); ceiling from dash[testing]'s selenium<=4.2.0 pin


### PR DESCRIPTION
Closes #42 (T-28).

**Stacked on #76** (end of the chain).

## Changes
- Ran the suite with `-W error::PytestRemovedIn9Warning` on pytest 8 first, per the issue — zero deprecations surfaced
- `pytest ^8.0.0` → `^9.0.0` (locks 9.1.1); lockfile refreshed (h3/pyproj are optional extras, constraints already compatible)

## Verification
- 239 tests + pytest-cov green on pytest 9.1.1 / Python 3.14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGRQWbBW1qH3UFfDEpxixp