### PR TITLE
Guard incompatible use_binary + multi_color/show_direction

### DIFF
--- a/deckgl_dash/layers/core.py
+++ b/deckgl_dash/layers/core.py
@@ -336,6 +336,19 @@ class PathLayer(BaseLayer):
 
     def to_dict(self) -> Dict[str, Any]:
         result = super().to_dict()
+        if self._show_direction or self._multi_color:
+            from ..binary import is_binary_data
+            if is_binary_data(result.get('data')):
+                flag = 'show_direction' if self._show_direction else 'multi_color'
+                raise ValueError(
+                    f"{flag}=True is incompatible with binary data: the custom path layers iterate JSON rows, "
+                    "which a binary block does not have. For per-segment colors with binary data, use the stock "
+                    "PathLayer with one color PER VERTEX and _path_type='open':\n"
+                    "    PathLayer(id, use_binary = True, _path_type = 'open',\n"
+                    "              data = {'getPath': verts, 'getColor': per_vertex_colors, 'startIndices': starts})\n"
+                    "See docs/guides/binary-data-transport.md. Direction arrows are not yet supported on binary "
+                    "paths (https://github.com/kihaji/deckgl-dash/issues/81)."
+                )
         if self._show_direction:
             # Composite that draws the line + arrows; it picks its line sublayer via multiColor.
             result['@@type'] = 'DirectedPathLayer'

--- a/tests/test_binary.py
+++ b/tests/test_binary.py
@@ -85,3 +85,40 @@ class TestUseBinaryFlag:
     def test_empty_data_dict_raises(self):
         with pytest.raises(ValueError, match = 'at least one accessor'):
             ScatterplotLayer(id = 'pts', use_binary = True, data = {}).to_dict()
+
+
+class TestIncompatibleBinaryCombos:
+    """multi_color / show_direction require JSON rows; binary data must raise clearly (issue #79)."""
+
+    def _binary_path_data(self):
+        return {'getPath': np.zeros((6, 2), dtype = np.float32), 'startIndices': np.array([0, 3], dtype = np.uint32)}
+
+    def test_multi_color_with_use_binary_raises(self):
+        from deckgl_dash.layers import PathLayer
+        layer = PathLayer(id = 'p', use_binary = True, multi_color = True, data = self._binary_path_data())
+        with pytest.raises(ValueError, match = 'multi_color'):
+            layer.to_dict()
+
+    def test_show_direction_with_use_binary_raises(self):
+        from deckgl_dash.layers import PathLayer
+        layer = PathLayer(id = 'p', use_binary = True, show_direction = True, data = self._binary_path_data())
+        with pytest.raises(ValueError, match = 'show_direction'):
+            layer.to_dict()
+
+    def test_prepacked_block_also_guarded(self):
+        from deckgl_dash.layers import PathLayer
+        block = binary_data(2, {'getPath': np.zeros((6, 2), dtype = np.float32)},
+                            start_indices = np.array([0, 3], dtype = np.uint32))
+        with pytest.raises(ValueError, match = 'PathLayer with one color PER VERTEX'):
+            PathLayer(id = 'p', multi_color = True, data = block).to_dict()
+
+    def test_stock_pathlayer_binary_still_fine(self):
+        from deckgl_dash.layers import PathLayer
+        d = PathLayer(id = 'p', use_binary = True, _path_type = 'open', data = self._binary_path_data()).to_dict()
+        assert d['@@type'] == 'PathLayer'
+        assert is_binary_data(d['data'])
+
+    def test_multi_color_json_unaffected(self):
+        from deckgl_dash.layers import PathLayer
+        d = PathLayer(id = 'p', multi_color = True, data = [], get_path = '@@=path').to_dict()
+        assert d['@@type'] == 'MultiColorPathLayer'


### PR DESCRIPTION
Closes #79. **Stacked on #78.**

## Changes
- `PathLayer.to_dict()` raises `ValueError` when `multi_color=True` or `show_direction=True` meets binary data (either `use_binary=True` or a prepacked `binary_data()` block) — previously an opaque render-time browser error
- The message spells out the working alternative (stock PathLayer + per-vertex colors + `_path_type='open'`), links the guide, and points at #81 for binary direction arrows
- 5 new tests: both flags × binary raise; prepacked blocks raise; stock-PathLayer binary and JSON `multi_color` unaffected

## Verification
- 255 tests green; `make quality` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGRQWbBW1qH3UFfDEpxixp