### PR TITLE
Document binary per-segment path colors

### DIFF
--- a/docs/guides/binary-data-transport.md
+++ b/docs/guides/binary-data-transport.md
@@ -55,6 +55,26 @@ layer = PolygonLayer(id = 'polys', use_binary = True, data = {
 Note: the composite `PolygonLayer` cannot take binary attributes — the component
 automatically re-types it to `SolidPolygonLayer` (no outlines).
 
+### Per-segment path colors
+
+Per-segment coloring needs **no custom layer** in binary mode — the stock `PathLayer`
+consumes a per-vertex color attribute directly (in JSON mode this requires
+`multi_color=True`, which is incompatible with binary data and raises if combined):
+
+```python
+# One flattened vertex array for all paths, one RGBA color PER VERTEX
+layer = PathLayer(id = 'tracks', use_binary = True, _path_type = 'open', width_min_pixels = 4,
+                  data = {'getPath': verts_f32,       # (total_verts, 2)
+                          'getColor': colors_u8,      # (total_verts, 4)
+                          'startIndices': starts_u32})
+```
+
+Color placement: each segment takes the color of its **leading vertex** — for a path
+of N points (N−1 segments), write segment *i*'s color at vertex *i*; the final
+vertex's color is unused. `_path_type = 'open'` (or `'loop'`) is required so deck.gl
+skips path normalization, which binary data cannot go through. Direction arrows
+(`show_direction=True`) are not yet supported on binary paths (issue #81).
+
 ## Picks and tooltips on binary layers
 
 Binary layers have no per-item JS objects, so:

--- a/examples/binary_path_colors_demo.py
+++ b/examples/binary_path_colors_demo.py
@@ -1,0 +1,53 @@
+"""
+Demo: per-segment path colors via binary transport (stock PathLayer).
+
+The JSON-mode equivalent needs PathLayer(multi_color=True); in binary mode the stock
+PathLayer consumes a per-vertex color attribute directly — write segment i's color at
+vertex i (the last vertex's color is unused). Scales to hundreds of thousands of
+segments with a fraction of the JSON payload and parse cost.
+
+Requires numpy: pip install deckgl-dash[binary]
+"""
+import numpy as np
+from dash import Dash, html
+
+from deckgl_dash import DeckGL
+from deckgl_dash.binary import binary_data
+
+# 60 tracks x 120 segments of random-walk paths around San Francisco
+N_PATHS, N_PTS = 60, 121
+rng = np.random.default_rng(7)
+starts = (np.arange(N_PATHS, dtype = np.uint32) * N_PTS)
+origins = rng.uniform([-122.52, 37.70], [-122.36, 37.83], size = (N_PATHS, 1, 2))
+steps = rng.normal(0, 0.0012, size = (N_PATHS, N_PTS, 2)).cumsum(axis = 1)
+verts = (origins + steps).astype(np.float32).reshape(-1, 2)
+
+# Color each SEGMENT by its speed (step length): blue = slow, red = fast.
+seg = verts.reshape(N_PATHS, N_PTS, 2)
+speed = np.linalg.norm(np.diff(seg, axis = 1), axis = 2)                       # (paths, pts-1)
+t = np.clip(speed / np.percentile(speed, 95), 0, 1)
+colors = np.zeros((N_PATHS, N_PTS, 4), dtype = np.uint8)
+colors[..., :N_PTS - 1 + 1, 3] = 255
+colors[:, :-1, 0] = (t * 255).astype(np.uint8)        # red rises with speed
+colors[:, :-1, 2] = ((1 - t) * 255).astype(np.uint8)  # blue falls
+colors[:, -1] = colors[:, -2]                          # final vertex color is unused; mirror it
+colors = colors.reshape(-1, 4)
+
+app = Dash(__name__)
+app.layout = html.Div([
+    html.H3("Binary per-segment path colors — 60 tracks colored by segment speed"),
+    DeckGL(
+        id = "map",
+        initial_view_state = {"longitude": -122.44, "latitude": 37.765, "zoom": 11.5},
+        style = {"width": "100%", "height": "620px", "position": "relative"},
+        layers = [
+            {"@@type": "TileLayer", "id": "basemap", "data": "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+             "minZoom": 0, "maxZoom": 19, "tileSize": 256},
+            {"@@type": "PathLayer", "id": "tracks", "widthMinPixels": 3, "_pathType": "open",
+             "data": binary_data(N_PATHS, {"getPath": verts, "getColor": colors}, start_indices = starts)},
+        ],
+    ),
+])
+
+if __name__ == "__main__":
+    app.run(debug = True, port = 8058)

--- a/tests/test_binary_paths.py
+++ b/tests/test_binary_paths.py
@@ -1,0 +1,41 @@
+"""Browser test: per-segment path colors via binary transport on the stock PathLayer
+(issues #80/#39). Requires a browser; opt in with DECKGL_BROWSER_TESTS=1 --headless."""
+import os
+import time
+
+import numpy as np
+import pytest
+from dash import Dash, html
+
+from deckgl_dash import DeckGL
+from deckgl_dash.binary import binary_data
+
+pytestmark = pytest.mark.skipif(not os.environ.get("DECKGL_BROWSER_TESTS"),
+                                reason = "browser test; set DECKGL_BROWSER_TESTS=1 (needs chromedriver + selenium>=4)")
+
+
+def _severe(dash_duo):
+    return [e for e in (dash_duo.get_logs() or [])
+            if e.get("level") == "SEVERE" and "favicon" not in str(e.get("message", ""))]
+
+
+def test_binary_pathlayer_per_vertex_colors(dash_duo):
+    # Two paths (4 + 3 points), flattened, with one RGBA color per vertex
+    verts = np.array([[-122.45, 37.77], [-122.43, 37.78], [-122.41, 37.77], [-122.40, 37.78],
+                      [-122.44, 37.75], [-122.42, 37.74], [-122.40, 37.75]], dtype = np.float32)
+    colors = np.array([[255, 0, 0, 255], [0, 255, 0, 255], [0, 0, 255, 255], [255, 255, 0, 255],
+                       [255, 0, 255, 255], [0, 255, 255, 255], [255, 128, 0, 255]], dtype = np.uint8)
+    starts = np.array([0, 4], dtype = np.uint32)
+
+    app = Dash(__name__)
+    app.layout = html.Div([DeckGL(
+        id = "map",
+        initial_view_state = {"longitude": -122.425, "latitude": 37.765, "zoom": 12},
+        style = {"width": "500px", "height": "400px", "position": "relative"},
+        layers = [{"@@type": "PathLayer", "id": "paths", "widthMinPixels": 6, "_pathType": "open",
+                   "data": binary_data(2, {"getPath": verts, "getColor": colors}, start_indices = starts)}],
+    )])
+    dash_duo.start_server(app)
+    dash_duo.wait_for_element("#map canvas")
+    time.sleep(3)
+    assert _severe(dash_duo) == []


### PR DESCRIPTION
Closes #80. **Stacked on #82.**

## Changes
- **Guide section** in `binary-data-transport.md`: per-segment colors on the stock `PathLayer` (per-vertex colors, `startIndices`, `_path_type='open'`), the leading-vertex color-placement rule, and the `multi_color` incompatibility that #82 now guards
- **Permanent browser test** `tests/test_binary_paths.py` (gated, runs in CI's browser step) — promoted from the throwaway verification
- **New example** `examples/binary_path_colors_demo.py`: 60 random-walk tracks × 120 segments colored by segment speed, fully binary

## Verification
- Browser test passes; example module executes and builds its layers; 255 tests; docs `--strict`; `make quality` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGRQWbBW1qH3UFfDEpxixp